### PR TITLE
[Bug] Fix for WordPress Sites

### DIFF
--- a/Scripts/SiteStatus.sh
+++ b/Scripts/SiteStatus.sh
@@ -29,7 +29,7 @@ while read p; do
         DISPLAYNAME=${WWW[1]}
     fi
 
-    response=$(curl -L --write-out %{http_code} --silent --output /dev/null ${WWW[0]})
+    response=$(/usr/bin/curl -L --referer ${WWW[0]} --user-agent "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36" --write-out %{http_code} --silent --output /dev/null ${WWW[0]})
 
     if [ $response -eq 200 ] ; then
         # Site up        


### PR DESCRIPTION
WordPress sites always returned 403 because the referrer and user agents are not filled in. This change makes the same site the referrer and sets the user agent to a recognizable value. This fixed the issues for me.